### PR TITLE
add fields and values required for licensing

### DIFF
--- a/templates/crds/user.yaml
+++ b/templates/crds/user.yaml
@@ -19,6 +19,8 @@ spec:
                   type: integer
                 email:
                   type: string
+                isServiceAccount:
+                  type: boolean
   scope: Namespaced
   names:
     plural: users

--- a/templates/titan/deployment.yaml
+++ b/templates/titan/deployment.yaml
@@ -51,6 +51,8 @@ spec:
               value: {{lower .Values.show }}
             - name: PROJECT_GUID
               value: "{{ .Values.guid }}"
+            - name: JUNO_LICENSE_TOKEN
+              value: "{{ .Values.juno_license_token }}"
           resources:
             requests:
               cpu: 500m


### PR DESCRIPTION
This matches the changes I've done to implement licensing in https://github.com/juno-fx/titan/pull/43

Since the change is backward-compatible, the change should work just fine here without adding a CRD version. I tested a helm upgrade on a local kind cluster.