### PR TITLE
make the http scheme&cert issuer configurable

### DIFF
--- a/templates/hubble/deployment.yaml
+++ b/templates/hubble/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - name: "AUTH_TRUST_HOST"
               value: "true"
             - name: "NEXTAUTH_URL"
-              value: "https://{{ .Values.host }}/api/auth"
+              value: "{{ tpl .Values.nextauth_url_tpl . }}"
             - name: "LUNA"
               value: "deactivated"
             - name: "TERRA"

--- a/templates/hubble/ingress.yaml
+++ b/templates/hubble/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   name: hubble-ingress
   annotations:
-    cert-manager.io/issuer: "letsencrypt-prod"
+    cert-manager.io/issuer: "{{ .Values.cert_manager_issuer }}"
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"

--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,10 @@ active: true                          # Whether the project is active
 image_pull_secret:                    # Image pull secret to use for the project. This is the name of the secret in the namespace
 genesis_proxy: true                   # Whether to use the Genesis proxy
 genesis_namespace: argocd             # Namespace where Genesis is deployed
+http_scheme: https
+nextauth_url_tpl: "{{ .Values.http_scheme }}://{{ .Values.host }}/api/auth"
+
+cert_manager_issuer: letsencrypt-prod
 
 volumes:
 #    - name:                          # Name of the mount


### PR DESCRIPTION
This makes the http scheme configurable.

The ability to use http over https is useful for:

1. POC deployments in isolated lab environments.
2. Community contributors.

The cert issuer tweak is unrelated - I just did it while I was in there.

This keeps the default behavior during installs the same - it doesn't need accounting for anywhere else.