### PR TITLE
allow the token creation within the project namespace

### DIFF
--- a/templates/hubble/project-binding.yaml
+++ b/templates/hubble/project-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: orion-hubble-{{ .Values.show }}
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: orion-hubble-{{ .Values.show }}
+subjects:
+  - kind: ServiceAccount
+    name: orion-hubble
+    namespace: {{ .Values.namespace }}

--- a/templates/hubble/project-role.yaml
+++ b/templates/hubble/project-role.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: orion-hubble-{{ .Values.show }}
+  namespace: {{ .Values.namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  verbs: ["create"]


### PR DESCRIPTION
argocd is incorrect in this case - we want short-lived creds within our NS

