### PR TITLE
bring clusterrole with workstation-logs perms for now

### DIFF
--- a/templates/kuiper/clusterrole.yaml
+++ b/templates/kuiper/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kuiper-{{ .Values.namespace }}
+rules:
+  - apiGroups: ["juno-innovations.com"]
+    resources: ["workstation-logs"]
+    verbs: ["list", "create", "delete", "get", "patch", "update"]

--- a/templates/kuiper/clusterrolebinding.yaml
+++ b/templates/kuiper/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuiper-{{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuiper-{{ .Values.namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: kuiper
+    namespace: {{ .Values.namespace }}


### PR DESCRIPTION
This likely can be a plain Role, but I'd rather bring it back as-is for now, since we aim to release soon. We can clean that out later (or remove the need for CRs entirely)