### PR TITLE
bring back the cluster-admin binding for kuiper

### DIFF
--- a/templates/kuiper/binding.yaml
+++ b/templates/kuiper/binding.yaml
@@ -12,7 +12,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: kuiper
+  name: kuiper-kuiper
   namespace: {{ .Values.namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -22,4 +22,19 @@ subjects:
   - kind: ServiceAccount
     name: kuiper
     namespace: {{ .Values.namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kuiper-cluster-admin
+  namespace: {{ .Values.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: kuiper
+    namespace: {{ .Values.namespace }}
+
 {{- end }}


### PR DESCRIPTION
This brings back the cluster-admin binding.
Note that now it is a Role instead of a ClusterRole.

This means:
1) kuiper can now do anything in a project/environment namespace, same
   as before. Eg. I can delete/create pods.

2) Kuiper can NOT do anything outside of the project/environment. it
   could before, but I don't think we use it nor should we.

   On current stable, Kuiper can for example delete argocd. I'd rather
   block that, this is what effectively will happen next release.
